### PR TITLE
Fix MetaMask network switching

### DIFF
--- a/frontend/src/utils/eth.ts
+++ b/frontend/src/utils/eth.ts
@@ -23,7 +23,7 @@ export const switchNetwork = async (provider: ethers.providers.Web3Provider, net
     return
   }
 
-  const chainId = ethers.utils.hexlify(networkId);
+  const chainId = '0x' + networkId.toString(16);
   try {
     await provider.provider.request({
       method: "wallet_switchEthereumChain",


### PR DESCRIPTION
For some reason `ethers.utils.hexlify` adds `\n` at the front of hex string which prevents network switching in MetaMask
<img width="692" alt="image" src="https://user-images.githubusercontent.com/7884477/169806363-36cb3d01-dab2-46ec-a6ff-358489be6078.png">